### PR TITLE
Move passport authentication after any static file middleware.

### DIFF
--- a/lib/passport.js
+++ b/lib/passport.js
@@ -311,8 +311,7 @@ api.createAuthenticator = function(options) {
   };
 };
 
-// configure passport before serving static files
-bedrock.events.on('bedrock-express.configure.static', function configure(app) {
+bedrock.events.on('bedrock-express.configure.router', function configure(app) {
   // TODO: add configuration options for default persistence of identity
   // information
 


### PR DESCRIPTION
Fixes an issue where passport authentication would run on any requests for static files, causing a lot of unneeded requests to the database.
