### PR TITLE
Use `exists` API.

### DIFF
--- a/lib/DidStrategy.js
+++ b/lib/DidStrategy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Digital Bazaar, Inc. All rights reserved.
  */
 var async = require('async');
 var bedrock = require('bedrock');

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 /*
  * Bedrock passport configuration.
  *
- * Copyright (c) 2012-2015 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2016 Digital Bazaar, Inc. All rights reserved.
  */
 var config = require('bedrock').config;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,6 @@ var async = require('async');
 var bedrock = require('bedrock');
 var brIdentity = require('bedrock-identity');
 var config = bedrock.config;
-var database = require('bedrock-mongodb');
 var passport = require('passport');
 var BedrockError = bedrock.util.BedrockError;
 var DidStrategy = require('./DidStrategy');
@@ -313,8 +312,8 @@ bedrock.events.on('bedrock-express.configure.router', function configure(app) {
   // information
 
   // define passport user serialization
-  passport.serializeUser(function(user, callback) {
-    /* Note: Here we take `user` from an authentication method and specify
+  passport.serializeUser((user, callback) => {
+    /* NOTE: Here we take `user` from an authentication method and specify
     the object that will be persisted in the session database. The `identity`
     property in `user` is given special treatment. If `identity` has an `id`
     property that can be retrieved via `bedrock-identity`, then we only
@@ -325,15 +324,11 @@ bedrock.events.on('bedrock-express.configure.router', function configure(app) {
     the session database. Once the session is gone, that information will
     also be gone. */
 
-    var query = {
-      id: database.hash(user.identity.id),
-      'identity.sysStatus': 'active'
-    };
-    brIdentity.getAll(null, query, {id: true}, function(err, results) {
+    brIdentity.exists(null, user.identity.id, (err, exists) => {
       if(err) {
         return callback(err);
       }
-      if(results.length === 0) {
+      if(!exists) {
         if(config.passport.identity.allowNonPersistent) {
           return callback(null, user);
         }
@@ -349,7 +344,7 @@ bedrock.events.on('bedrock-express.configure.router', function configure(app) {
     });
   });
   passport.deserializeUser(function(data, callback) {
-    /* Note: Here we specify how to populate the `req.body.user` property
+    /* NOTE: Here we specify how to populate the `req.body.user` property
     used by express routes using information from the session. The `data`
     object was populated with whatever information was previously stored in
     the session database for the current session ID. If the `identity` property

--- a/package.json
+++ b/package.json
@@ -35,9 +35,8 @@
   "peerDependencies": {
     "bedrock": "^1.0.0",
     "bedrock-express": "^2.0.0",
-    "bedrock-identity": "^4.0.0",
-    "bedrock-key": "^3.0.0",
-    "bedrock-mongodb": "^3.0.0"
+    "bedrock-identity": "^4.5.0",
+    "bedrock-key": "^3.0.0"
   },
   "directories": {
     "lib": "./lib"

--- a/test/package.json
+++ b/test/package.json
@@ -28,7 +28,7 @@
     "bedrock": "^1.0.0",
     "bedrock-docs": "^2.0.2",
     "bedrock-express": "^2.0.0",
-    "bedrock-identity": "^4.0.0",
+    "bedrock-identity": "^4.5.0",
     "bedrock-key": "^3.0.0",
     "bedrock-mongodb": "^3.0.0",
     "bedrock-permission": "^2.3.2",


### PR DESCRIPTION
The `bedrock-mongodb` dependency was only needed for the `hash` API which is no longer required.

This update has been tested with top level module test suites.