### PR TITLE
Support http-signatures "(request-target").

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # bedrock-passport ChangeLog
 
+### Changed
+- Update to support http-signatures "(request-target)" as well as the older
+  "request-line".
+
 ## 3.4.1 - 2017-09-04
 
 ### Fixed

--- a/lib/HttpSignatureStrategy.js
+++ b/lib/HttpSignatureStrategy.js
@@ -18,7 +18,8 @@ var request = require('request');
 
 module.exports = Strategy;
 
-var REQUIRED_HEADERS = ['request-line', 'host', 'date'];
+var REQUIRED_HEADERS_OLD = ['request-line', 'host', 'date'];
+var REQUIRED_HEADERS = ['(request-target)', 'host', 'date'];
 
 bedrock.events.on('bedrock.init', function() {
   // get configured lib instances
@@ -87,6 +88,12 @@ Strategy.prototype.authenticate = function(req) {
       var diff = _.difference(
         REQUIRED_HEADERS,
         results.parseRequest.params.headers);
+      if(diff.length > 0) {
+        // old headers also valid
+        diff = _.difference(
+          REQUIRED_HEADERS_OLD,
+          results.parseRequest.params.headers);
+      }
       if(diff.length > 0) {
         return callback(new BedrockError(
           'Missing required headers in HTTP signature.',


### PR DESCRIPTION
Support both newer "(request-target)" and older "request-line".