### PR TITLE
Use brkey promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # bedrock-passport ChangeLog
 
+### Added
+- Support promises for `authenticate` and `authenticateAll`.
+- Include `strategies` and `identities` in `user` (and therefore `req.user`).
+
+### Changed
+- ***BREAKING*** Use named parameters in public API.
+- ***BREAKING*** `authenticate` no longer create an express middleware, use
+  `createMiddleware` for that.
+- ***BREAKING*** `checkAuthenticate` has been changed to `authenticateAll`.
+
+### Removed
+- ***BREAKING*** `info` is no longer used or returned in authenticate events.
+
 ## 3.4.2 - 2018-02-23
 
 ### Changed

--- a/lib/DidStrategy.js
+++ b/lib/DidStrategy.js
@@ -3,13 +3,14 @@
  */
 'use strict';
 
-const async = require('async');
 const bedrock = require('bedrock');
 let cio = require('credentials-io');
+let cioVerify;
 const didio = require('did-io');
 const passport = require('passport');
 const util = require('util');
-const BedrockError = bedrock.util.BedrockError;
+const {promisify} = util;
+const {BedrockError} = bedrock.util;
 const URL = require('url');
 
 module.exports = Strategy;
@@ -30,6 +31,11 @@ function Strategy() {
     wrap: (url, callback) => bedrock.jsonld.documentLoader(url, callback),
   });
   cio.use('jsonld', jsonld, {configure: false});
+
+  // FIXME: remove once `did-io` 0.7+ and vc.js are available
+  cioVerify = promisify((identity, options = {}, callback) => {
+    cio.verify(identity, options, callback);
+  });
 }
 util.inherits(Strategy, passport.Strategy);
 
@@ -38,7 +44,7 @@ util.inherits(Strategy, passport.Strategy);
  *
  * @param req the request to authenticate.
  */
-Strategy.prototype.authenticate = function(req) {
+Strategy.prototype.authenticate = async req => {
   const self = this;
 
   // TODO: use WHATWG URL parser once node 8.x is required
@@ -55,37 +61,34 @@ Strategy.prototype.authenticate = function(req) {
   // check POST data for an identity with a DID and a valid signature
   // pass to credentials-io for verification of the identity and all
   // credentials
-  async.auto({
-    verify: callback => {
-      const identity = req.body;
-      cio.verify(identity, callback);
-    }
-  }, (err, results) => {
-    if(err) {
-      return self.error(err);
-    }
-    if(!results.verify.verified) {
-      return self.error(new BedrockError(
-        'Identity credential signature verification failed.',
-        'SignatureNotVerified'));
-    }
-    if(!domains.includes(results.verify.domain)) {
-      return self.error(new BedrockError(
-        'Identity credential signature domain mismatch.',
-        'DomainMismatch', {
-          givenDomain: results.verify.domain,
-          expectedDomain: domains
-        }));
-    }
-    // TODO: need to support use case of "upgrading" from being authenticated
-    //   as the owner of an `account` to ALSO being the owner of an `identity`
-    //   that is not yet managed by the `account` ... only then will all the
-    //   capabilities required be present to start managing an identity
-    // TODO: see `httpSignatureStrategy` to add `account` and `actor`
-    req.user = {
-      identity: results.verify.identity,
-      credentials: results.verify.credentials
-    };
-    self.success(req.user);
-  });
+  let results;
+  try {
+    results = await cioVerify(req.body);
+  } catch(e) {
+    return self.error(e);
+  }
+
+  if(!results.verify.verified) {
+    return self.error(new BedrockError(
+      'Signature verification failed.',
+      'SecurityError'));
+  }
+  if(!domains.includes(results.verify.domain)) {
+    return self.error(new BedrockError(
+      'Signature domain mismatch.',
+      'URLMismatchError', {
+        givenDomain: results.verify.domain,
+        expectedDomain: domains
+      }));
+  }
+  // TODO: need to support use case of "upgrading" from being authenticated
+  //   as the owner of an `account` to ALSO being the owner of an `identity`
+  //   that is not yet managed by the `account` ... only then will all the
+  //   capabilities required be present to start managing an identity
+  // TODO: see `httpSignatureStrategy` to add `account` and `actor`
+  req.user = {
+    identity: results.verify.identity,
+    credentials: results.verify.credentials
+  };
+  self.success(req.user);
 };

--- a/lib/httpSignatureStrategy.js
+++ b/lib/httpSignatureStrategy.js
@@ -9,7 +9,6 @@ const brIdentity = require('bedrock-identity');
 const brKey = require('bedrock-key');
 const Middleware = require('http-signature-middleware');
 let jsigs = require('jsonld-signatures');
-const {promisify} = require('util');
 const {BedrockError} = bedrock.util;
 let didio = require('did-io');
 let jsonld = require('jsonld');
@@ -17,7 +16,7 @@ let jsonld = require('jsonld');
 const api = {};
 module.exports = api;
 
-api.strategy = new Middleware({name: 'signature'});
+api.strategy = new Middleware();
 api.strategy.use('getKey', _getKey);
 api.strategy.use('getUser', _getUser);
 api.strategy.use('validateRequest', _validateRequest);
@@ -36,10 +35,9 @@ bedrock.events.on('bedrock.init', () => {
   api.strategy.use('jsigs', jsigs);
 });
 
-const brKeyGetPublicKey = promisify(brKey.getPublicKey);
 async function _getKey(keyQuery) {
   try {
-    const {publicKey} = await brKeyGetPublicKey({publicKey: keyQuery});
+    const {publicKey} = await brKey.getPublicKey({publicKey: keyQuery});
     return publicKey;
   } catch(err) {
     if(err && err.name === 'NotFoundError') {
@@ -62,6 +60,7 @@ async function _getUser({keyDoc}) {
       return {
         id: owner,
         identity: {
+          // TODO: determine if this context is necessary or implied
           '@context': bedrock.config.constants.IDENTITY_CONTEXT_V1_URL,
           id: owner
         }
@@ -86,7 +85,11 @@ async function _getUser({keyDoc}) {
       brAccount.getCapabilities({id: user.account.id})]);
   } else {
     // no `account`, so copy identity into actor
-    user.actor = Object.assign({}, identity);
+    user.actor = {
+      // TODO: deprecate `id` on actor
+      id: identity.id,
+      sysResourceRole: [].concat(identity.sysResourceRole || [])
+    };
   }
 
   return user;
@@ -97,8 +100,8 @@ async function _validateRequest(req) {
   if(host !== bedrock.config.server.host) {
     throw new BedrockError(
       'Host header contains an invalid host name.',
-      'HttpSignature.InvalidHostHeader', {
-        'public': true,
+      'SyntaxError', {
+        public: true,
         httpStatusCode: 400,
         headers: {host}
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,15 +3,13 @@
  */
 'use strict';
 
-const _ = require('lodash');
-const async = require('async');
 const bedrock = require('bedrock');
 const brAccount = require('bedrock-account');
 const brIdentity = require('bedrock-identity');
 const {callbackify} = require('util');
 const config = bedrock.config;
 const passport = require('passport');
-const BedrockError = bedrock.util.BedrockError;
+const {BedrockError, callbackify: brCallbackify} = bedrock.util;
 const DidStrategy = require('./DidStrategy');
 const httpSignatureStrategy = require('./httpSignatureStrategy');
 const URL = require('url');
@@ -58,88 +56,81 @@ api.use = options => {
 };
 
 /**
- * Returns express middleware that will authenticate a request using the given
- * `strategy`. The event `bedrock-passport.authenticate` will be emitted
- * with the strategy, options, and user information.
+ * Authenticates an express request using the given `strategy`. The event
+ * `bedrock-passport.authenticate` will be emitted with the strategy, options,
+ * and user information.
  *
  * @param strategy the name of the strategy to use.
+ * @param req the express request.
+ * @param res the express response.
  * @param [options] the options to use.
- * @param callback(err, user, info) the callback to call once authentication
- *          has been attempted.
  *
- * @return the middleware express route that is expecting a request, response,
- *           and next middleware function.
+ * @return a Promise that resolves once the authentication has been attempted
+ *   with an object containing `user`.
  */
-api.authenticate = (strategy, options, callback) => {
-  if(typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-  options = options || {};
+api.authenticate = brCallbackify(({strategy, req, res, options = {}}) => {
+  const emit = async ({user}) => {
+    if(user) {
+      await bedrock.events.emit(
+        'bedrock-passport.authenticate', {strategy, options, user});
+    }
+    return {user};
+  };
+
   // handle built-in session-based authentication
   if(strategy === 'session') {
-    return (req, res, next) => {
-      // ensure authN event after successful authN
-      const done = emitter(callback || function(err) {
-        next(err);
-      });
-      // restrict session-based authentication to when:
-      // 1. There is no origin header set.
-      // 2. The origin header matches the host header.
-      // 3. The request method is in a list of default permitted CORS methods.
-      // TODO: add an option to allow controlling permittedCorsMethods for
-      // particular handlers that know what they're doing
-      const origin = ('origin' in req.headers ?
-        URL.parse(req.headers.origin).host : null);
-      if(origin === null || req.headers.host === origin ||
-        permittedCorsMethods.indexOf(req.method) !== -1 ||
-        _checkAllowedHosts(origin, options.allowHosts)) {
-        if(options.allowUrlEncoded || !(
-          req.is('urlencoded') || req.is('multipart'))) {
-          // reuse existing check (express auto-runs a session check per
-          // code below with `app.use(api.authenticate('session'))`
-          // TODO: potentially refactor to avoid this auto-check in the future,
-          // but it would be a breaking change
-          // FIXME: `req.isAuthenticated` is not technically granular enough
-          // to determine if `session` strategy was responsible for previous
-          // authentication, but presently works because session is always
-          // checked and if another method was concurrently checked, both would
-          // fail if the user didn't match; however, should the automatic
-          // session check be removed, then the degenerate case where a user
-          // was authenticated via another method and then checked against
-          // session this will pass when it should potentially fail
-          if(options.reuse && req.isAuthenticated()) {
-            return done(null, req.user);
-          }
-          return passport.authenticate('session', options)(
-            req, res, err => done(err, req.user || false));
+    // restrict session-based authentication to when:
+    // 1. There is no origin header set.
+    // 2. The origin header matches the host header.
+    // 3. The request method is in a list of default permitted CORS methods.
+    // TODO: add an option to allow controlling permittedCorsMethods for
+    // particular handlers that know what they're doing
+    const origin = ('origin' in req.headers ?
+      URL.parse(req.headers.origin).host : null);
+    if(origin === null || req.headers.host === origin ||
+      permittedCorsMethods.indexOf(req.method) !== -1 ||
+      _checkAllowedHosts(origin, options.allowHosts)) {
+      if(options.allowUrlEncoded || !(
+        req.is('urlencoded') || req.is('multipart'))) {
+        // reuse existing check (express auto-runs a session check per
+        // code below with
+        // `app.use(api.createMiddleware({strategy: 'session'}))`
+        // TODO: potentially refactor to avoid this auto-check in the future,
+        // but it would be a breaking change
+        // FIXME: `req.isAuthenticated` is not technically granular enough
+        // to determine if `session` strategy was responsible for previous
+        // authentication, but presently works because session is always
+        // checked and if another method was concurrently checked, both would
+        // fail if the user didn't match; however, should the automatic
+        // session check be removed, then the degenerate case where a user
+        // was authenticated via another method and then checked against
+        // session this will pass when it should potentially fail
+        if(options.reuse && req.isAuthenticated()) {
+          return emit({user: req.user || false});
         }
+        return new Promise((resolve, reject) => {
+          passport.authenticate('session', options)(req, res, err => {
+            if(err) {
+              return reject(err);
+            }
+            resolve(emit({user: req.user || false}));
+          });
+        });
       }
-      return done(null, false);
-    };
-  }
-
-  if(typeof callback !== 'function') {
-    throw new TypeError('callback must be a function.');
+    }
+    return {user: false};
   }
 
   // handle non-built-in strategies
-  return passport.authenticate(strategy, options, emitter(callback));
-
-  function emitter(callback) {
-    return (err, user, info) => {
-      if(!err && user) {
-        return bedrock.events.emit('bedrock-passport.authenticate', {
-          strategy: strategy,
-          options: options,
-          user: user,
-          info: info
-        }, err => callback(err, user, info));
+  return new Promise((resolve, reject) => {
+    passport.authenticate(strategy, options)(req, res, err => {
+      if(err) {
+        return reject(err);
       }
-      callback(err, user, info);
-    };
-  }
-};
+      resolve(emit({user: req.user || false}));
+    });
+  });
+});
 
 /**
  * Checks authentication of a request using all registered strategies. The
@@ -153,79 +144,145 @@ api.authenticate = (strategy, options, callback) => {
  * @param [options] options to use:
  *          [strategyOptions] an object of strategy-specific options, keyed by
  *            strategy name.
- * @param callback(err, result) called with error or null and the
- *          found auth info as {strategies: {}, user: identity} or false.
+ *
+ * @return a Promise that resolves once all registered strategies have been
+ *         checked with an object that looks like:
+ *         results: {name: {user: [false || user]}}, user: [false || user]}
  */
-api.checkAuthentication = (req, res, options, callback) => {
-  if(typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
-
-  const result = {};
-
+api.authenticateAll = brCallbackify(async ({req, res, options = {}}) => {
   // try all strategies in parallel
-  const parallel = Object.keys(strategies).map(name => {
-    const strategy = strategies[name];
-    const config = bedrock.config.passport.strategies[name] || {};
-    return callback => {
+  let authResults;
+  const names = Object.keys(strategies);
+  const strategyConfigs = bedrock.config.passport.strategies;
+  try {
+    authResults = await Promise.all(names.map(name => {
+      const strategy = strategies[name];
+      const config = strategyConfigs[name] || {};
       // skip check if not auto or 'disabled' flag is set for the strategy
       if(!strategy.auto || config.disabled) {
-        return callback(null, false);
+        return false;
       }
       // overlay passed options over built-in options
-      const strategyOptions = _.assign(
+      const strategyOptions = Object.assign(
         {}, strategy.options || {},
         (options.strategyOptions || {})[name] || {});
       if(name === 'session') {
         // special hidden option to reuse built-in session check
         strategyOptions.reuse = true;
       }
-      api.authenticate(name, strategyOptions, (err, user) => {
-        result[name] = err ? false : user;
-        callback(err, user);
-      })(req, res, err => callback(err));
-    };
-  });
-
-  async.auto({
-    auth: callback => async.parallel(parallel, callback),
-    compare: ['auth', (results, callback) => {
-      // TODO: need to allow user to authenticate as a single account, but
-      // also simultaneously identities that may not be managed under that
-      // account ... to allow for the account to become a manager of them
-      // ... this gets more complicated when the identity is managed by
-      // another account already
-
-      // do not permit more than one attempted strategy
-      let user_ = false;
-      for(const name in result) {
-        const user = result[name];
-        if(!user) {
-          continue;
-        }
-        if(user_) {
-          return callback(new BedrockError(
-            'Multiple simultaneous authentication methods are disallowed.',
-            'NotAllowedError',
-            {'public': true, httpStatusCode: 400}));
-        }
-        user_ = user;
-      }
-      callback(null, user_);
-    }]
-  }, (err, results) => {
-    // 400 if there is an error
-    if(err) {
-      if(!(err instanceof BedrockError) && err.name && err.message) {
-        err = new BedrockError(err.message, err.name, {public: true});
-      }
-      return callback(new BedrockError(
-        'Request authentication error.', 'NotAllowedError',
-        {'public': true, httpStatusCode: 400}, err));
+      return api.authenticate({
+        strategy: name,
+        req,
+        res,
+        options: strategyOptions
+      });
+    }));
+  } catch(e) {
+    // 400 if there is an error because it is presumed to be client's fault
+    if(!(e instanceof BedrockError) && e.name && e.message) {
+      e = new BedrockError(e.message, e.name, {public: true});
     }
-    callback(null, {strategies: result, user: results.compare});
+    throw new BedrockError(
+      'Request authentication error.', 'NotAllowedError',
+      {'public': true, httpStatusCode: 400}, e);
+  }
+
+  let user = false;
+  const results = {};
+  authResults.forEach((result, index) => {
+    const name = names[index];
+    results[name] = result;
+    if(!user && result.user) {
+      // set request user
+      user = Object.assign({}, result.user);
+      return;
+    }
+
+    // TODO: may want to allow users to authenticate as multiple accounts when
+    //   a user wants to switch the account that is managing their identity;
+    //   we support a mechanism that is simpler to implement (but perhaps more
+    //   frustrating for the user) that requires them to drop management using
+    //   the current account first then log into the new account and
+    //   authenticate as the identity to set the new managing account
+
+    // multiple `users` have authenticated -- check to see if more than a
+    // single `account` has been used, which is not allowed
+    if(user && user.account && result.user.account) {
+      throw new BedrockError(
+        'Authenticating as multiple accounts at once is not allowed.',
+        'NotAllowedError',
+        {'public': true, httpStatusCode: 400});
+    }
+
+    if(result.user) {
+      // combine actor capabilities
+      if(result.user.actor) {
+        const {actor = null} = user;
+        if(!actor) {
+          user.actor = Object.assign({}, result.user.account);
+        } else {
+          user.actor = Object.assign({}, user.actor);
+          const resourceRolesA = user.actor.sysResourceRole || [];
+          const resourceRolesB = result.user.actor.sysResourceRole || [];
+          user.actor.sysResourceRole = resourceRolesA.concat(resourceRolesB);
+        }
+      }
+
+      // track all identities
+      if(result.user.identity) {
+        if(!user.identities) {
+          user.identities = [result.user.identity];
+        } else {
+          user.identities.push(result.user.identity);
+        }
+      }
+    }
   });
+  if(user) {
+    user.strategies = results;
+    // TODO: which `identity`? it is possible to authenticate as multiple, so
+    // for now, we just allow *any* to occupy this space ... we don't have
+    // a way of selecting a `default` one or anything of that sort
+    if(user.identity) {
+      if(!user.actor) {
+        // no `actor`, so create from identity
+        user.actor = {
+          // TODO: deprecate `id` on actor
+          id: user.identity.id,
+          sysResourceRole: [].concat(user.identity.sysResourceRole || [])
+        };
+      }
+      if(!user.identities) {
+        // ensure `identities` is present for simplicity
+        user.identities = [user.identity];
+      }
+    }
+    if(!user.actor) {
+      // no capabilities granted
+      user.actor = {sysResourceRole: []};
+    }
+  }
+  return {results, user};
+});
+
+/**
+ * Returns express middleware that will authenticate a request using the given
+ * `strategy`. The event `bedrock-passport.authenticate` will be emitted
+ * with the strategy, options, and user information.
+ *
+ * @param strategy the name of the strategy to use.
+ * @param [options] the options to use.
+ *
+ * @return the middleware express route that is expecting a request, response,
+ *           and next middleware function.
+ */
+api.createMiddleware = ({strategy, options = {}}) => async (req, res, next) => {
+  try {
+    await api.authenticate({strategy, req, res, options});
+  } catch(e) {
+    return next(e);
+  }
+  next();
 };
 
 /**
@@ -237,17 +294,17 @@ api.checkAuthentication = (req, res, options, callback) => {
  * @param res the response.
  * @param next the next route handler.
  */
-api.optionallyAuthenticated = (req, res, next) => {
-  api.checkAuthentication(req, res, (err, info) => {
-    if(err) {
-      return next(err);
+api.optionallyAuthenticated = async (req, res, next) => {
+  try {
+    const {user} = await api.authenticateAll({req, res});
+    // if authentication found, set req.user
+    if(user) {
+      req.user = user;
     }
-    // if authorization found, set req.user
-    if(info) {
-      req.user = info.user;
-    }
-    next();
-  });
+  } catch(e) {
+    return next(e);
+  }
+  next();
 };
 
 /**
@@ -293,23 +350,23 @@ api.ensureAuthenticated = (req, res, next) => {
  */
 api.createAuthenticator = options => {
   options = options || {};
-  return (req, res, next) => {
-    api.checkAuthentication(req, res, options, (err, info) => {
-      if(err) {
-        return next(err);
+  return async (req, res, next) => {
+    try {
+      const {user} = await api.authenticateAll({req, res, options});
+      // if authentication found, set req.user
+      if(user) {
+        req.user = user;
       }
-      // if authorization found, set req.user
-      if(info) {
-        req.user = info.user;
-      }
-      if(req.user || options.optional) {
-        return next();
-      }
-      // not authenticated
-      next(new BedrockError(
-        'Not authenticated.', 'NotAllowedError',
-        {'public': true, httpStatusCode: 400}));
-    });
+    } catch(e) {
+      return next(e);
+    }
+    if(req.user || options.optional) {
+      return next();
+    }
+    // not authenticated
+    next(new BedrockError(
+      'Not authenticated.', 'NotAllowedError',
+      {'public': true, httpStatusCode: 400}));
   };
 };
 
@@ -321,8 +378,10 @@ bedrock.events.on('bedrock-express.configure.router', function configure(app) {
   // init and attach passport
   app.use(passport.initialize(bedrock.config.passport.initialize));
 
+  // FIXME: consider not running this automatically (breaking change)
+
   // special-register built-in session authentication to always run
-  app.use(api.authenticate('session'));
+  app.use(api.createMiddleware({strategy: 'session'}));
   api.use({
     strategy: {name: 'session'},
     auto: true
@@ -368,7 +427,7 @@ async function _serializeUser(user) {
       dataToSave.identity = user.identity.id;
     } else if(config.passport.identity.allowNonPersistent) {
       // save entire user
-      _.assign(dataToSave, user);
+      Object.assign(dataToSave, user);
     } else {
       throw new BedrockError('Identity not found.', 'NotFoundError', {
         id: user.identity.id,
@@ -426,7 +485,7 @@ async function _deserializeUser(data) {
 
   if(typeof data.identity !== 'string') {
     // use all data
-    _.assign(user, data);
+    Object.assign(user, data);
   } else {
     try {
       // look up persistent identity

--- a/package.json
+++ b/package.json
@@ -22,24 +22,20 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-passport",
   "dependencies": {
-    "async": "^2.6.0",
     "credentials-io": "~0.2.0",
     "did-io": "^0.6.1",
     "http-signature-middleware": "digitalbazaar/http-signature-middleware#master",
     "jsonld": "^1.0.1",
     "jsonld-signatures": "^2.3.0",
-    "jsprim": "^2.0.0",
-    "lodash": "^4.0.0",
-    "passport": "~0.2.1",
-    "request": "^2.75.0"
+    "passport": "~0.2.1"
   },
   "peerDependencies": {
-    "bedrock": "^1.0.0",
+    "bedrock": "^1.12.1",
     "bedrock-account": "^1.0.0",
     "bedrock-did-client": "^1.0.0",
     "bedrock-express": "^2.0.0",
     "bedrock-identity": "^5.0.0",
-    "bedrock-key": "^4.0.0"
+    "bedrock-key": "^5.1.0"
   },
   "directories": {
     "lib": "./lib"

--- a/test/package.json
+++ b/test/package.json
@@ -25,10 +25,9 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-passport",
   "dependencies": {
-    "async": "^2.6.0",
     "axios": "^0.18.0",
-    "bedrock": "^1.0.0",
-    "bedrock-account": "digitalbazaar/bedrock-account#implementation",
+    "bedrock": "^1.12.1",
+    "bedrock-account": "^1.0.0",
     "bedrock-did-client": "^1.0.0",
     "bedrock-docs": "^2.0.2",
     "bedrock-express": "^2.0.0",
@@ -41,6 +40,7 @@
     "bedrock-server": "^2.1.2",
     "bedrock-test": "^2.0.0",
     "bedrock-validation": "^2.2.0",
-    "bedrock-views": "^5.4.0"
+    "bedrock-views": "^5.4.0",
+    "jsprim": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR uses the latest bedrock-key, promises internally, updates the API to use them and named parameters externally and addresses the multi-authN issue (authenticating with more than one identity) by combining capabilities in `req.user.actor`.