### PR TITLE
Use bedrock-did-client 2.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "bedrock": "^1.12.1",
     "bedrock-account": "^1.0.0",
-    "bedrock-did-client": "^1.0.0",
+    "bedrock-did-client": "^2.0.0",
     "bedrock-express": "^2.0.0",
     "bedrock-identity": "^5.0.0",
     "bedrock-key": "^5.1.0"

--- a/test/package.json
+++ b/test/package.json
@@ -28,7 +28,7 @@
     "axios": "^0.18.0",
     "bedrock": "^1.12.1",
     "bedrock-account": "^1.0.0",
-    "bedrock-did-client": "^1.0.0",
+    "bedrock-did-client": "^2.0.0",
     "bedrock-docs": "^2.0.2",
     "bedrock-express": "^2.0.0",
     "bedrock-identity": "^5.0.0",


### PR DESCRIPTION
@dlongley what sort of release should this be?

bedrock-did-client@2 uses did-io@0.7.x.