### PR TITLE
Throw with account id over identity id.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -440,7 +440,7 @@ async function _serializeUser(user) {
       {actor: null, id: user.account.id});
     if(!exists) {
       throw new BedrockError('Account not found.', 'NotFoundError', {
-        id: user.identity.id,
+        id: user.account.id,
         httpStatusCode: 404,
         public: true
       });


### PR DESCRIPTION
When an account is not found we are returning `user.identity.id` when we should be returning the `user.account.id`.

