### PR TITLE
Use passport ^0.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-passport ChangeLog
 
+## 7.0.0 - TBD
+
+### Changed
+- **BREAKING:**: Upgrade to `passport: ^0.5.0`.
+- **BREAKING:**: Upgrade Peer Dependency to `bedrock: ^4.0.0`.
+- **BREAKING:**: Upgrade Peer Dependency to `bedrock-express: ^5.0.0`.
+- **BREAKING:**: Set `engines.node >= 12.0.0`.
+
 ## 6.1.0 - 2021-01-12
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
     "passport": "^0.5.0"
   },
   "peerDependencies": {
-    "bedrock": "1.12.1 - 3.x",
+    "bedrock": "^4.0.0",
     "bedrock-account": "2.x - 5.x",
-    "bedrock-express": "2.x - 3.x"
+    "bedrock-express": "^5.0.0"
   },
   "directories": {
     "lib": "./lib"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=12.0.0"
   },
   "devDependencies": {
     "eslint": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-passport",
   "dependencies": {
-    "passport": "~0.4.0"
+    "passport": "^0.5.0"
   },
   "peerDependencies": {
     "bedrock": "1.12.1 - 3.x",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "bedrock": "^4.0.0",
-    "bedrock-account": "2.x - 5.x",
+    "bedrock-account": "^5.0.0",
     "bedrock-express": "^5.0.0"
   },
   "directories": {


### PR DESCRIPTION
Upgrades passport to latest version which corrects some bugs involving `passport.initialize`:

https://github.com/jaredhanson/passport/blob/master/CHANGELOG.md


> Fixed
> userProperty option to initialize() middleware only affects the current request, rather than all requests processed via singleton Passport instance, eliminating a race condition in situations where initialize() middleware is used multiple times in an application with userProperty set to different values.


Version 0.5.0 of passport also removes the monkeyPatch method of adding `req.login` to node's http incoming messages:

Now:
https://github.com/jaredhanson/passport/blob/master/lib/middleware/initialize.js

Previously:
https://github.com/jaredhanson/passport/blob/42ff63c60ae55f466d21332306e9112295c0535e/lib/framework/connect.js

This seems like a big improvement and removes potential prototypical issues.

This is a DRAFT PR until:

- [x] A CHANGELOG entry is made
- [x] Consensus on this being a major or minor release
- [ ] At least one other developer that saw the race condition can confirm they are no longer getting it
- [x] [This branch has been removed.](https://github.com/digitalbazaar/bedrock-passport/tree/eliminate-passport-race-condition)